### PR TITLE
Security: replace is_root with nix wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "clap"
 version = "4.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,16 +205,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
-name = "is-root"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9df98242b01855f02bede53e1c2c90411af31b71d744936272cb21ab3a77ee9e"
-dependencies = [
- "users",
- "winapi",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,6 +254,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,8 +282,8 @@ dependencies = [
  "anyhow",
  "clap",
  "fuser",
- "is-root",
  "libc",
+ "nix",
  "nvml-wrapper",
  "tracing",
  "tracing-subscriber",
@@ -534,16 +542,6 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "users"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
-dependencies = [
- "libc",
- "log",
-]
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ edition = "2021"
 anyhow = "1.0.86"
 clap = { version = "4.5.16", features = ["derive", "string"] }
 fuser = "0.14.0"
-is-root = "0.1.3"
 libc = "0.2.158"
+nix = { version = "0.29.0", features = ["user"] }
 nvml-wrapper = "0.10.0"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,6 @@ use anyhow::{bail, Context};
 use clap::Parser;
 use file_system::NvSensorFs;
 use fuser::{mount2, MountOption};
-use is_root::is_root;
 use nvml_wrapper::Nvml;
 use std::fs;
 use std::path::PathBuf;
@@ -24,7 +23,7 @@ fn main() -> anyhow::Result<()> {
 
     let args = Args::parse();
 
-    if !is_root() {
+    if nix::unistd::Uid::effective().is_root() {
         bail!("This command has to be run with superuser privileges.");
     }
 


### PR DESCRIPTION
`is_root` depends `users` which is an unmaintained crate with potential security issues